### PR TITLE
Fix mobile window closing

### DIFF
--- a/components/ContactWindow.js
+++ b/components/ContactWindow.js
@@ -46,14 +46,16 @@ export default function ContactWindow({ onClose }) {
       bounds="parent"
       enableResizing={false}
       className="z-50"
+      dragHandleClassName="drag-handle"
+      cancel=".no-drag"
     >
       <div className="flex flex-col w-full h-full bg-[#f2f2f2] border border-gray-300 rounded-xl shadow-md overflow-hidden font-sans">
         {/* Barra superior */}
-        <div className="flex items-center justify-between px-3 py-1 bg-[#e5e5e5] border-b border-gray-300 rounded-t-xl">
+        <div className="drag-handle flex items-center justify-between px-3 py-1 bg-[#e5e5e5] border-b border-gray-300 rounded-t-xl cursor-move">
           <div className="flex space-x-2">
-            <div className="w-3 h-3 rounded-full bg-red-500 cursor-pointer" onClick={onClose}></div>
-            <div className="w-3 h-3 rounded-full bg-yellow-400"></div>
-            <div className="w-3 h-3 rounded-full bg-green-500"></div>
+            <div className="no-drag w-3 h-3 rounded-full bg-red-500 cursor-pointer" onClick={onClose}></div>
+            <div className="no-drag w-3 h-3 rounded-full bg-yellow-400" onClick={onClose}></div>
+            <div className="no-drag w-3 h-3 rounded-full bg-green-500" onClick={onClose}></div>
           </div>
           <span className="text-sm text-gray-700">Contact Me</span>
           <div className="w-16" />

--- a/components/PdfViewerWindow.js
+++ b/components/PdfViewerWindow.js
@@ -60,17 +60,19 @@ export default function PdfViewerWindow({ onClose }) {
       onDragStop={handleDragStop}
       className="z-50"
       enableResizing={false}
+      dragHandleClassName="drag-handle"
+      cancel=".no-drag"
     >
       <div className="w-full h-full flex flex-col bg-white border border-gray-300 shadow-lg rounded-xl overflow-hidden">
         {/* Barra superior estilo macOS Preview */}
-        <div className="flex items-center justify-between px-3 py-1 bg-[#e5e5e5] border-b border-gray-300 rounded-t-xl">
+        <div className="drag-handle flex items-center justify-between px-3 py-1 bg-[#e5e5e5] border-b border-gray-300 rounded-t-xl cursor-move">
           <div className="flex space-x-2">
             <div
-              className="w-3 h-3 rounded-full bg-red-500 cursor-pointer"
+              className="no-drag w-3 h-3 rounded-full bg-red-500 cursor-pointer"
               onClick={onClose} // Cerrar ventana al pulsar botón rojo
             />
-            <div className="w-3 h-3 rounded-full bg-yellow-400 cursor-pointer" onClick={onClose} />
-            <div className="w-3 h-3 rounded-full bg-green-500 cursor-pointer" onClick={onClose} />
+            <div className="no-drag w-3 h-3 rounded-full bg-yellow-400 cursor-pointer" onClick={onClose} />
+            <div className="no-drag w-3 h-3 rounded-full bg-green-500 cursor-pointer" onClick={onClose} />
           </div>
           <span className="text-sm text-gray-700">CV_2025.pdf</span>
           <div className="w-16" />

--- a/components/PhotoViewerWindow.js
+++ b/components/PhotoViewerWindow.js
@@ -41,18 +41,20 @@ export default function PhotoViewerWindow({ onClose, photoSrc }) {
       onDragStop={handleDragStop}
       className="z-50"
       enableResizing={false}
+      dragHandleClassName="drag-handle"
+      cancel=".no-drag"
     >
       <div className="w-full h-full flex flex-col bg-black rounded-xl overflow-hidden">
         {/* Barra superior estilo macOS */}
-        <div className="flex items-center justify-between px-3 py-1 bg-[#e5e5e5] border-b border-gray-300 rounded-t-xl select-none">
+        <div className="drag-handle flex items-center justify-between px-3 py-1 bg-[#e5e5e5] border-b border-gray-300 rounded-t-xl select-none cursor-move">
           <div className="flex space-x-2">
             <div
-              className="w-3 h-3 rounded-full bg-red-500 cursor-pointer"
+              className="no-drag w-3 h-3 rounded-full bg-red-500 cursor-pointer"
               onClick={onClose} // Cerrar ventana al pulsar botón rojo
               title="Close"
             />
-            <div className="w-3 h-3 rounded-full bg-yellow-400 cursor-pointer" onClick={onClose} title="Close" />
-            <div className="w-3 h-3 rounded-full bg-green-500 cursor-pointer" onClick={onClose} title="Close" />
+            <div className="no-drag w-3 h-3 rounded-full bg-yellow-400 cursor-pointer" onClick={onClose} title="Close" />
+            <div className="no-drag w-3 h-3 rounded-full bg-green-500 cursor-pointer" onClick={onClose} title="Close" />
           </div>
           <span className="text-sm text-gray-700 select-none">My Photo</span>
           <div className="w-16" />

--- a/components/SettingsMenu.js
+++ b/components/SettingsMenu.js
@@ -32,23 +32,25 @@ export default function SettingsMenu({
       bounds="parent"
       enableResizing={false}
       className="z-50"
+      dragHandleClassName="drag-handle"
+      cancel=".no-drag"
     >
       <div className="w-full h-full bg-[#f2f2f2] rounded-xl border border-gray-300 shadow-md flex flex-col font-sans">
         {/* Header */}
-        <div className="flex items-center justify-between bg-[#e5e5e5] border-b border-gray-300 rounded-t-xl px-3 py-2">
+        <div className="drag-handle flex items-center justify-between bg-[#e5e5e5] border-b border-gray-300 rounded-t-xl px-3 py-2 cursor-move">
           <div className="flex space-x-2">
             <div
-              className="w-3 h-3 rounded-full bg-red-500 cursor-pointer"
+              className="no-drag w-3 h-3 rounded-full bg-red-500 cursor-pointer"
               onClick={onClose} // Cerrar al pulsar botón rojo
               title="Close"
             ></div>
             <div
-              className="w-3 h-3 rounded-full bg-yellow-400 cursor-pointer"
+              className="no-drag w-3 h-3 rounded-full bg-yellow-400 cursor-pointer"
               onClick={onClose} // También cerrar con amarillo
               title="Close"
             ></div>
             <div
-              className="w-3 h-3 rounded-full bg-green-500 cursor-pointer"
+              className="no-drag w-3 h-3 rounded-full bg-green-500 cursor-pointer"
               onClick={onClose} // Y con verde también
               title="Close"
             ></div>

--- a/components/TextEditWindow.js
+++ b/components/TextEditWindow.js
@@ -61,19 +61,21 @@ export default function TextEditWindow({ onClose, children }) {
       onDragStop={handleDragStop}
       className="z-40"
       enableResizing={false}
+      dragHandleClassName="drag-handle"
+      cancel=".no-drag"
     >
       <div
         className="w-full h-full flex flex-col bg-[#f2f2f2] shadow-md rounded-xl border border-gray-300 font-sans"
         style={{ fontFamily: `"Helvetica Neue", Helvetica, Arial, sans-serif` }}
       >
         {/* Header */}
-        <div className="flex items-center justify-between px-3 py-1 bg-[#e5e5e5] border-b border-gray-300 rounded-t-xl">
+        <div className="drag-handle flex items-center justify-between px-3 py-1 bg-[#e5e5e5] border-b border-gray-300 rounded-t-xl cursor-move">
           <div className="flex space-x-2">
-            <div className="w-3 h-3 rounded-full bg-red-500 cursor-pointer" onClick={onClose}></div>
-            <div className="w-3 h-3 rounded-full bg-yellow-400 cursor-pointer" onClick={onClose}></div>
-            <div className="w-3 h-3 rounded-full bg-green-500 cursor-pointer" onClick={onClose}></div>
+            <div className="no-drag w-3 h-3 rounded-full bg-red-500 cursor-pointer" onClick={onClose}></div>
+            <div className="no-drag w-3 h-3 rounded-full bg-yellow-400 cursor-pointer" onClick={onClose}></div>
+            <div className="no-drag w-3 h-3 rounded-full bg-green-500 cursor-pointer" onClick={onClose}></div>
           </div>
-          <span className="text-sm text-gray-700">About Me.txt</span>
+          <span className="text-sm text-gray-700 select-none">About Me.txt</span>
           <div className="w-16" />
         </div>
 


### PR DESCRIPTION
## Summary
- prevent drag gestures from blocking touch events on mobile
- apply `dragHandleClassName` and `cancel` in all floating windows

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6868202423448323944d6c9956f18e41