### PR TITLE
Adjust window and icon sizing

### DIFF
--- a/components/PdfViewerWindow.js
+++ b/components/PdfViewerWindow.js
@@ -30,8 +30,8 @@ export default function PdfViewerWindow({ onClose }) {
         setPosition({ x: 200, y: 150 });
       }
     } else {
-      const width = windowWidth < 640 ? Math.min(800, windowWidth - 40) : 800;
-      const height = windowWidth < 640 ? Math.min(600, windowHeight - 80) : 600;
+      const width = windowWidth < 640 ? Math.min(600, windowWidth - 40) : 800;
+      const height = windowWidth < 640 ? Math.min(500, windowHeight - 80) : 600;
       setPosition({
         x: Math.max(20, (windowWidth - width) / 2),
         y: Math.max(20, (windowHeight - height) / 2),
@@ -47,8 +47,8 @@ export default function PdfViewerWindow({ onClose }) {
 
   if (!position) return null;
 
-  const width = windowWidth < 640 ? Math.min(800, windowWidth - 40) : 800;
-  const height = windowWidth < 640 ? Math.min(600, windowHeight - 80) : 600;
+  const width = windowWidth < 640 ? Math.min(600, windowWidth - 40) : 800;
+  const height = windowWidth < 640 ? Math.min(500, windowHeight - 80) : 600;
 
   return (
     <Rnd

--- a/components/PhotoViewerWindow.js
+++ b/components/PhotoViewerWindow.js
@@ -4,6 +4,21 @@ import { Rnd } from "react-rnd";
 export default function PhotoViewerWindow({ onClose, photoSrc }) {
   const storageKey = "window-pos-photoViewer";
   const [position, setPosition] = useState(null);
+  const [windowWidth, setWindowWidth] = useState(
+    typeof window !== "undefined" ? window.innerWidth : 1024
+  );
+  const [windowHeight, setWindowHeight] = useState(
+    typeof window !== "undefined" ? window.innerHeight : 768
+  );
+
+  useEffect(() => {
+    const updateWindowSize = () => {
+      setWindowWidth(window.innerWidth);
+      setWindowHeight(window.innerHeight);
+    };
+    window.addEventListener("resize", updateWindowSize);
+    return () => window.removeEventListener("resize", updateWindowSize);
+  }, []);
 
   useEffect(() => {
     const saved = localStorage.getItem(storageKey);
@@ -31,10 +46,13 @@ export default function PhotoViewerWindow({ onClose, photoSrc }) {
 
   if (!position) return null;
 
+  const width = windowWidth < 640 ? Math.min(500, windowWidth - 40) : 600;
+  const height = windowWidth < 640 ? Math.min(500, windowHeight - 80) : 600;
+
   return (
     <Rnd
       position={position}
-      size={{ width: 600, height: 600 }}
+      size={{ width, height }}
       minWidth={400}
       minHeight={400}
       bounds="parent"

--- a/components/SettingsMenu.js
+++ b/components/SettingsMenu.js
@@ -1,5 +1,5 @@
 import { Rnd } from "react-rnd";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 const wallpapers = [
   "/wallpaper3.jpg",
@@ -20,13 +20,31 @@ export default function SettingsMenu({
   setTextSize,
 }) {
   const [position, setPosition] = useState({ x: 150, y: 150 });
+  const [windowWidth, setWindowWidth] = useState(
+    typeof window !== "undefined" ? window.innerWidth : 1024
+  );
+  const [windowHeight, setWindowHeight] = useState(
+    typeof window !== "undefined" ? window.innerHeight : 768
+  );
+
+  useEffect(() => {
+    const handleResize = () => {
+      setWindowWidth(window.innerWidth);
+      setWindowHeight(window.innerHeight);
+    };
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
 
   const folderSizes = ["small", "medium", "large"];
   const textSizes = ["small", "medium", "large"];
 
+  const width = windowWidth < 640 ? Math.min(500, windowWidth - 40) : 600;
+  const height = windowWidth < 640 ? Math.min(460, windowHeight - 80) : 460;
+
   return (
     <Rnd
-      size={{ width: 600, height: 460 }}
+      size={{ width, height }}
       position={position}
       onDragStop={(e, d) => setPosition({ x: d.x, y: d.y })}
       bounds="parent"

--- a/pages/index.js
+++ b/pages/index.js
@@ -47,17 +47,17 @@ export default function Home() {
 
   const icons = [
     { id: "about", icon: "/icons/txt.png", label: "About me.txt", defaultPosition: { x: 60, y: 80 } },
-    { id: "cv", icon: "/icons/pdf.png", label: "CV_2025.pdf", defaultPosition: { x: 60, y: 160 } },
+    { id: "cv", icon: "/icons/pdf.png", label: "CV_2025.pdf", defaultPosition: { x: 60, y: 240 } },
     {
       id: "project4",
       icon: "/icons/github.png",
       label: "GitHub",
-      defaultPosition: { x: 60, y: 320 },
+      defaultPosition: { x: 60, y: 400 },
       externalLink: "https://github.com/SalvaIvars", // Cambia aquí por tu GitHub
     },
     { id: "trash", icon: "/icons/trash.png", label: "Don't look in here", defaultPosition: { x: 60, y: 560 } },
-    { id: "settings", icon: "/icons/gear.png", label: "Settings", defaultPosition: { x: 60, y: 640 } },
-    { id: "profilePic", icon: "/icons/profilepicture_thumb.png", label: "My Photo", defaultPosition: { x: 300, y: 80 } },
+    { id: "settings", icon: "/icons/gear.png", label: "Settings", defaultPosition: { x: 60, y: 720 } },
+    { id: "profilePic", icon: "/icons/profilepicture_thumb.png", label: "My Photo", defaultPosition: { x: 260, y: 80 } },
   ];
 
   const updatePosition = (id, newPos) => {
@@ -85,11 +85,11 @@ export default function Home() {
         } else if (isMobile) {
           const col = index % 2;
           const row = Math.floor(index / 2);
-          pos = { x: 20 + col * 250, y: 150 + row * 240 };
+          pos = { x: 20 + col * 180, y: 150 + row * 200 };
         } else if (isTablet) {
           const col = index % 3;
           const row = Math.floor(index / 3);
-          pos = { x: 20 + col * 250, y: 150 + row * 240 };
+          pos = { x: 20 + col * 180, y: 150 + row * 200 };
         } else {
           pos = icon.defaultPosition;
         }


### PR DESCRIPTION
## Summary
- tune `SettingsMenu` width and height responsively
- make `PhotoViewerWindow` responsive
- shrink `PdfViewerWindow` a bit on mobile
- reduce starting icon spacing

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686834601c488323bf12bd6a1c8cf362