### PR TITLE
Prevent icons being dragged under navbar

### DIFF
--- a/components/DesktopIcon.js
+++ b/components/DesktopIcon.js
@@ -17,6 +17,9 @@ export default function DesktopIcon({
   const pointerDownPos = useRef({ x: 0, y: 0 });
   const clickAllowed = useRef(true);
 
+  const navbarHeight =
+    typeof window !== "undefined" && window.innerWidth >= 768 ? 80 : 64;
+
   const handleDragStart = (e, data) => {
     dragging.current = true;
     clickAllowed.current = true;
@@ -34,7 +37,9 @@ export default function DesktopIcon({
 
     clickAllowed.current = !moved;
 
-    onPositionChange({ x: data.x, y: data.y });
+    const clampedY = Math.max(data.y, navbarHeight);
+
+    onPositionChange({ x: data.x, y: clampedY });
   };
 
   // Pointer events
@@ -112,7 +117,7 @@ export default function DesktopIcon({
       onDragStart={handleDragStart}
       onDragStop={handleDragStop}
       enableResizing={false}
-      bounds={isMobile ? "window" : "parent"}
+      bounds={isMobile ? { top: navbarHeight, left: 0, right: 0, bottom: 0 } : { top: navbarHeight, left: 0, right: 0, bottom: 0 }}
       style={{ position: "absolute", cursor: dragging.current ? "grabbing" : "grab" }}
     >
       <div


### PR DESCRIPTION
## Summary
- clamp the icon's vertical position so it can't be dropped under the navbar
- restrict drag bounds to start below the navbar

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6868467d7e1083239242e56eaf260bb8